### PR TITLE
offer to export local changes

### DIFF
--- a/client/changes.coffee
+++ b/client/changes.coffee
@@ -42,7 +42,15 @@ constructor = ($, dependencies={})->
       slug = localStorage.key(i)
       page = JSON.parse(localStorage.getItem(slug))
       ul.append listItemHtml(slug,page)
-    ul.append """<button class="submit">Submit Changes</button>""" if item.submit?
+    if localStorage.length > 0
+      if item.submit?
+        ul.append """<button class="submit">Submit Changes</button>"""
+      else
+        $div.append """
+          <p> Click <i>Export Changes</i> to retrieve changed pages as json.
+          Save the json as a file to be drop-imported elsewhere.</p>
+          <ul><button class="export">Export Changes</button></ul>
+        """
 
   bind = ($div, item) ->
     $div.on 'click', '.delete', ->
@@ -70,6 +78,8 @@ constructor = ($, dependencies={})->
         error: (xhr, type, msg) ->
           wiki.log "ajax error callback", type, msg
 
+    $div.on 'click', '.export', ->
+      location.href = "data:application/json," + encodeURIComponent(JSON.stringify(pageBundle()));
 
     $div.dblclick ->
       bundle = pageBundle()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-changes",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Federated Wiki - Changes Plug-in",
   "keywords": [
     "wiki",


### PR DESCRIPTION
This pull request uses a data url to present the user with json for local changes that can be saved as a local file. This will be useful for moving changes from a read-only site to one where they can be saved.

![image](https://cloud.githubusercontent.com/assets/12127/16180030/00d9f634-362d-11e6-9d9b-05150a38b935.png)
