### PR TITLE
Localstorage collisions

### DIFF
--- a/client/changes.coffee
+++ b/client/changes.coffee
@@ -11,11 +11,11 @@ escape = (line) ->
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
 
-listItemHtml = (slug, page)->
+listItemHtml = (slug, title)->
   """
     <li>
       <a class="internal" href="#" title="local" data-page-name="#{slug}" data-site="local">
-        #{escape page.title}
+        #{escape title}
       </a>
       <button class="delete">✕</button>
     </li>
@@ -41,7 +41,8 @@ constructor = ($, dependencies={})->
     for i in [0...localStorage.length]
       slug = localStorage.key(i)
       page = JSON.parse(localStorage.getItem(slug))
-      ul.append listItemHtml(slug,page)
+      if page.title?
+        ul.append listItemHtml(slug,page.title)
     if localStorage.length > 0
       if item.submit?
         ul.append """<button class="submit">Submit Changes</button>"""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-changes",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Federated Wiki - Changes Plug-in",
   "keywords": [
     "wiki",


### PR DESCRIPTION
BitDefender has a browser plugin which saves web-site-specific data in browser `localStorage`.  The objects so saved do not have a key named 'title' which breaks the rendering of this changes plugin.

Here we check all the items in `localStorage` and only add the ones that have titles.
